### PR TITLE
Add in browser config for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "browserify-shim": {
     "d3": "global:d3",
     "canvas": "global:canvas"
+  },
+  "browser": {
+    "canvas": false
   }
 }


### PR DESCRIPTION
This enables vega to be built by webpack by excluding canvas when compiling for the web, otherwise there are a number of errors. This configuration is already included in the main vega project, but needs to be here as well in order to work.