### PR TITLE
Fix bound.js: Test if subgroup has bounds to union

### DIFF
--- a/src/util/bound.js
+++ b/src/util/bound.js
@@ -211,7 +211,7 @@ function group(g, bounds, includeLegends) {
       bounds.union(axes[j].bounds);
     }
     for (j=0, m=items.length; j<m; ++j) {
-      bounds.union(items[j].bounds);
+      if (items[j].bounds) bounds.union(items[j].bounds);
     }
     if (includeLegends) {
       for (j=0, m=legends.length; j<m; ++j) {


### PR DESCRIPTION
In one of my Vega graphs, I have nested `group` marks. My data is filterable via signals. If too much data gets filtered, some subgroups may lose all their backing data and they lose the `bounds` property. Vega then crashes downstream of the `bounds.union()` call that I patched in this PR, when it tries to update the bounds of the parent group.

This may also have an effect on vega/vega#559 which seems to crash for the same reason.