### PR TITLE
Fix IE bug when null passed to insertBefore

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify-versionify": "^1.0.4",
     "chai": "^3.0.0",
     "istanbul": "latest",
-    "jsdom": "^3.0.0",
+    "jsdom": "^9.1.0",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "tv4": "^1.1.12",

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -33,7 +33,7 @@ module.exports = {
         a.tagName.toLowerCase() !== tag.toLowerCase() ||
         className && a.getAttribute('class') != className) {
       a = create(el.ownerDocument, tag, ns);
-      el.insertBefore(a, b);
+      el.insertBefore(a, b || null);
       if (className) a.setAttribute('class', className);
     }
     return a;


### PR DESCRIPTION
Fix a error occurring in IE when an undefined value was passed to
insertBefore. This bug prevents vega being used in IE 10.

`insertBefore(newElement, referenceElement)`: If referenceElement is
null, newElement is inserted at the end of the list of child nodes.
In Internet Explorer, an undefined value as referenceElement will
throw an "Invalid argument" exception, while in rest of the modern
browsers, this works fine.