### PR TITLE
It seems the shortcut check should be with angles, not radius

### DIFF
--- a/src/bound/boundContext.js
+++ b/src/bound/boundContext.js
@@ -35,7 +35,7 @@ context.bezierCurveTo = function(x1, y1, x2, y2, x3, y3) {
 };
 
 context.arc = function(cx, cy, r, sa, ea, ccw) {
-  if (r === tau) {
+  if (ea - sa === tau) {
     add(cx - r, cy - r);
     add(cx + r, cy + r);
     return;


### PR DESCRIPTION
With many (100,000) circle symbols, the shortcut was not being taken
resulting in over 30% of the time in the update() for arc calculating
sin and cos. This fix lowers the time evaluating arc bounds to about 5%
and increases the frame rate.

I think this check is sufficient for the circle symbol, but there may be
able to be a stronger check for other full-circle arcs (other multiples of tau,
negative multiples of tau?).