### PR TITLE
SVG node binding got skipped if the node is not newly created and it is the first child of the parent

### DIFF
--- a/src/SVGRenderer.js
+++ b/src/SVGRenderer.js
@@ -335,7 +335,7 @@ function bind(item, el, sibling, tag) {
     }
   }
 
-  if (doc || node.previousSibling !== sibling) {
+  if (doc || node.previousSibling !== sibling || !sibling) {
     el.insertBefore(node, sibling ? sibling.nextSibling : el.firstChild);
   }
 


### PR DESCRIPTION
When binding a scenegraph item to an SVG DOM element (the `bind` function),
if the `item._svg` is not newly created (i.e. `doc` is undefined), and both `node.previousSibling` and `sibling` are `null` (i.e. first child of the `el`), the `if` condition will not hit and hence the item will never be inserted into the parent.

This happens in the following scenario:
the parent node was first bound to child `A`, and later with a signal update, the parent then is bound to child `B` and `C`. When the signal value switches back, the parent node is supposed to be bound to child `A` again. However, due to the miss of the `if` condition, the parent node is actually bound to child `B`.