### PR TITLE
removed comma expressions

### DIFF
--- a/src/Bounds.js
+++ b/src/Bounds.js
@@ -24,7 +24,7 @@ prototype.empty = function() {
     this.x2 === -Number.MAX_VALUE &&
     this.y2 === -Number.MAX_VALUE
   );
-}
+};
 
 prototype.set = function(x1, y1, x2, y2) {
   if (x2 < x1) {

--- a/src/CanvasRenderer.js
+++ b/src/CanvasRenderer.js
@@ -31,7 +31,8 @@ prototype.initialize = function(el, width, height, origin) {
 prototype.resize = function(width, height, origin) {
   base.resize.call(this, width, height, origin);
   resize(this._canvas, this._width, this._height, this._origin);
-  return this._redraw = true, this;
+  this._redraw = true;
+  return this;
 };
 
 prototype.canvas = function() {
@@ -80,9 +81,12 @@ prototype._render = function(scene) {
 
   // setup
   g.save();
-  b = (this._redraw || b.empty())
-    ? (this._redraw = false, null)
-    : clipToBounds(g, b, o);
+  if (this._redraw || b.empty()) {
+    this._redraw = false;
+    b = null;
+  } else {
+    b = clipToBounds(g, b, o);
+  }
 
   this.clear(-o[0], -o[1], w, h);
 

--- a/src/bound/boundContext.js
+++ b/src/bound/boundContext.js
@@ -4,7 +4,8 @@ var bounds,
     circleThreshold = tau - 1e-8;
 
 export default function context(_) {
-  return bounds = _, context;
+  bounds = _;
+  return context;
 }
 
 function noop() {}

--- a/src/bound/boundMark.js
+++ b/src/bound/boundMark.js
@@ -12,7 +12,13 @@ export default function(mark, bounds, opt) {
       i, n, item, b;
 
   if (type.nested) {
-    item = hasItems ? items[0] : (DUMMY.mark = mark, DUMMY); // no items, fake it
+    if (hasItems) {
+      item = items[0];
+    } else {
+      // no items, fake it
+      DUMMY.mark = mark;
+      item = DUMMY;
+    }
     b = boundItem(item, bound, opt);
     bounds = bounds && bounds.union(b) || b;
     return bounds;

--- a/src/marks/markMultiItemPath.js
+++ b/src/marks/markMultiItemPath.js
@@ -12,8 +12,12 @@ export default function(type, shape) {
 
   function bound(bounds, mark) {
     var items = mark.items;
-    return items.length === 0 ? bounds
-      : (shape(context(bounds), items), boundStroke(bounds, items[0]));
+    if (items.length === 0) {
+      return bounds;
+    } else {
+      shape(context(bounds), items);
+      return boundStroke(bounds, items[0]);
+    }
   }
 
   function draw(context, items) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -34,5 +34,10 @@ modules[None] = {};
 
 export function renderModule(name, _) {
   name = String(name || '').toLowerCase();
-  return arguments.length > 1 ? (modules[name] = _, this) : modules[name];
+  if (arguments.length > 1) {
+    modules[name] = _;
+    return this;
+  } else {
+    return modules[name];
+  }
 }

--- a/src/path/rectangle.js
+++ b/src/path/rectangle.js
@@ -55,31 +55,64 @@ export default function() {
       context.closePath();
     }
 
-    if (buffer) return context = null, buffer + '' || null;
+    if (buffer) {
+      context = null;
+      return buffer + '' || null;
+    }
   }
 
   rectangle.x = function(_) {
-    return arguments.length ? (x = typeof _ === 'function' ? _ : constant(+_), rectangle) : x;
+    if (arguments.length) {
+      x = typeof _ === 'function' ? _ : constant(+_);
+      return rectangle;
+    } else {
+      return x;
+    }
   };
 
   rectangle.y = function(_) {
-    return arguments.length ? (y = typeof _ === 'function' ? _ : constant(+_), rectangle) : y;
+    if (arguments.length) {
+      y = typeof _ === 'function' ? _ : constant(+_);
+      return rectangle;
+    } else {
+      return y;
+    }
   };
 
   rectangle.width = function(_) {
-    return arguments.length ? (width = typeof _ === 'function' ? _ : constant(+_), rectangle) : width;
+    if (arguments.length) {
+      width = typeof _ === 'function' ? _ : constant(+_);
+      return rectangle;
+    } else {
+      return width;
+    }
   };
 
   rectangle.height = function(_) {
-    return arguments.length ? (height = typeof _ === 'function' ? _ : constant(+_), rectangle) : height;
+    if (arguments.length) {
+      height = typeof _ === 'function' ? _ : constant(+_);
+      return rectangle;
+    } else {
+      return height;
+    }
   };
 
   rectangle.cornerRadius = function(_) {
-    return arguments.length ? (cornerRadius = typeof _ === 'function' ? _ : constant(+_), rectangle) : cornerRadius;
+    if (arguments.length) {
+      cornerRadius = typeof _ === 'function' ? _ : constant(+_);
+      return rectangle;
+    } else {
+      return cornerRadius;
+    }
   };
 
   rectangle.context = function(_) {
-    return arguments.length ? (context = _ == null ? null : _, rectangle) : context;
+    if (arguments.length) {
+      context = _ == null ? null : _;
+      return rectangle;
+    } else {
+      return context;
+    }
   };
 
   return rectangle;

--- a/src/path/trail.js
+++ b/src/path/trail.js
@@ -37,7 +37,9 @@ export default function() {
     } else {
       ready = 1;
     }
-    x1 = x2, y1 = y2, r1 = r2;
+    x1 = x2;
+    y1 = y2;
+    r1 = r2;
   }
 
   function trail(data) {
@@ -56,27 +58,59 @@ export default function() {
       if (defined0) point(+x(d, i, data), +y(d, i, data), +size(d, i, data));
     }
 
-    if (buffer) return context = null, buffer + '' || null;
+    if (buffer) {
+      context = null;
+      return buffer + '' || null;
+    }
   }
 
   trail.x = function(_) {
-    return arguments.length ? (x = _, trail) : x;
+    if (arguments.length) {
+      x = _;
+      return trail;
+    } else {
+      return x;
+    }
   };
 
   trail.y = function(_) {
-    return arguments.length ? (y = _, trail) : y;
+    if (arguments.length) {
+      y = _;
+      return trail;
+    } else {
+      return y;
+    }
   };
 
   trail.size = function(_) {
-    return arguments.length ? (size = _, trail) : size;
+    if (arguments.length) {
+      size = _;
+      return trail;
+    } else {
+      return size;
+    }
   };
 
   trail.defined = function(_) {
-    return arguments.length ? (defined = _, trail) : defined;
+    if (arguments.length) {
+      defined = _;
+      return trail;
+    } else {
+      return defined;
+    }
   };
 
   trail.context = function(_) {
-    return arguments.length ? (_ == null ? context = null : context = _, trail) : context;
+    if (arguments.length) {
+      if (_ == null) {
+        context = null;
+      } else {
+        context = _;
+      }
+      return trail;
+    } else {
+      return context;
+    }
   };
 
   return trail;

--- a/src/util/text.js
+++ b/src/util/text.js
@@ -15,8 +15,8 @@ canvas(true);
 
 // make dumb, simple estimate if no canvas is available
 function estimateWidth(item) {
-  height(item);
-  return fontHeight = estimate(textValue(item));
+  fontHeight = height(item)
+  return estimate(textValue(item));
 }
 
 function estimate(text) {
@@ -25,8 +25,8 @@ function estimate(text) {
 
 // measure text width if canvas is available
 function measureWidth(item) {
-  font(item);
-  return context.font = measure(textValue(item));
+  context.font = font(item);
+  return measure(textValue(item));
 }
 
 function measure(text) {

--- a/src/util/text.js
+++ b/src/util/text.js
@@ -15,7 +15,8 @@ canvas(true);
 
 // make dumb, simple estimate if no canvas is available
 function estimateWidth(item) {
-  return fontHeight = height(item), estimate(textValue(item));
+  height(item);
+  return fontHeight = estimate(textValue(item));
 }
 
 function estimate(text) {
@@ -24,7 +25,8 @@ function estimate(text) {
 
 // measure text width if canvas is available
 function measureWidth(item) {
-  return context.font = font(item), measure(textValue(item));
+  font(item);
+  return context.font = measure(textValue(item));
 }
 
 function measure(text) {
@@ -44,15 +46,25 @@ function canvas(_) {
 
 export function textValue(item) {
   var s = item.text;
-  return s == null ? '' : item.limit > 0 ? truncate(item) : s + '';
+  if (s == null) {
+    return '';
+  } else {
+    return item.limit > 0 ? truncate(item) : s + '';
+  }
 }
 
 export function truncate(item) {
   var limit = +item.limit,
       text = item.text + '',
-      width = context
-        ? (context.font = font(item), measure)
-        : (fontHeight = height(item), estimate);
+      width;
+
+  if (context) {
+    context.font = font(item);
+    width = measure;
+  } else {
+    fontHeight = height(item);
+    width = estimate;
+  }
 
   if (width(text) < limit) return text;
 

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -35,7 +35,7 @@ tape('Handler should parse event names', function(test) {
 });
 
 tape('Handler should return array of handlers', function(test) {
-  var obj = {}
+  var obj = {};
   var h = new Handler();
   test.deepEqual(h.handlers(), []);
   h._handlers = {'click':[obj]};


### PR DESCRIPTION
Obfuscation contest winner, especially with the "_" as the variable name:
 return arguments.length ? (width = typeof _ === 'function' ? _ : constant(+_), rectangle) : width;

After looking at it for a while, it became clearer, but this is almost impossible to debug
for a non-involved developer.  Also, it clearly shows a usage pattern, which could
be moved to a separate function.