### PR TITLE
Include canvas-prebuilt as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "vega-util": "^1.1"
   },
   "optionalDependencies": {
-    "canvas": "^1.6"
+    "canvas": "^1.6",
+    "canvas-prebuilt": "^1.6"
   },
   "devDependencies": {
     "eslint": "4",

--- a/src/util/canvas/canvas.js
+++ b/src/util/canvas/canvas.js
@@ -2,7 +2,10 @@ import {domCreate} from '../dom';
 
 export var Canvas;
 
-try { Canvas = require('canvas'); } catch (e) { Canvas = null; }
+try {
+  Canvas = require('canvas');
+  Canvas = Canvas || require('canvas-prebuilt');
+} catch (e) { Canvas = null; }
 
 export default function(w, h) {
   var canvas = domCreate(null, 'canvas');


### PR DESCRIPTION
`canvas` has external dependencies during the build process.

This makes it impossible to export images in serverless services like AWS lambda and Google cloud function as `canvas` cannot be built successfully.

`canvas-prebuilt` can serve as a drop-in replacement for `canvas` in such environments.