### PR TITLE
pass undefined to tooltip handler

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -81,6 +81,6 @@ prototype.handleHref = function(event, item, href) {
 prototype.handleTooltip = function(event, item, show) {
   if (item && item.tooltip != null) {
     this._tooltip.call(this._obj, this, event, item,
-      show ? item.tooltip : null);
+      show ? item.tooltip : undefined);
   }
 };


### PR DESCRIPTION
`null` could be a valid value to show (especially useful for debugging).  Before the last patch, tooltip handler was getting `undefined` when tooltip was suppose to hide.  This patch reverts back to that behavior.  See https://github.com/vega/vega-tooltip/issues/189